### PR TITLE
SNAG::Source::vserver Changes

### DIFF
--- a/lib/SNAG.pm
+++ b/lib/SNAG.pm
@@ -18,7 +18,7 @@ use Config::General qw/ParseConfig/;
 
 our %flags;
 
-our $VERSION = '4.41';
+our $VERSION = '4.42';
 sub VERSION { $VERSION };
 
 my ($os, $dist, $ver);

--- a/lib/SNAG/Source/vserver.pm
+++ b/lib/SNAG/Source/vserver.pm
@@ -43,7 +43,7 @@ sub new
           foreach (`/usr/sbin/vserver-stat`)
           {
     				my @stats = split (/[' ']+/, $_);
-						next if $stats[7] =~ /[^(root|NAME)]/;
+						next if $stats[7] =~ /^(root|NAME)/;
 						$kernel->post('client' => 'sysrrd' => 'load' => join RRD_SEP, (HOST_NAME, 'processes_' . $stats[7], "1g", time(), $stats[1]));
 						$kernel->post('client' => 'master' => 'heartbeat' => { source  => SCRIPT_NAME, host => $stats[7] , seen => time2str("%Y-%m-%d %T", time) } );
 						push @{$SNAG::Dispatch::shared_data->{vservers}}, $stats[7];


### PR DESCRIPTION
Two character regex tweak.  

Previously the 'root' vserver was not being ignored when parsing the output of /usr/sbin/vserver-stat.  This commit fixes that.

Now when snagc is ran with --debug, we'll no longer see the following message:

Can not find a vserver-setup at '/etc/vservers/root/'.

Possible solutions:
- fix the spelling of the 'root' vserver name
- read 'vserver root build --help' about ways to create a new vserver
- see 'vserver --help' for the syntax of this command
