### PR TITLE
SNAG::Source::SystemInfo::Linux

### DIFF
--- a/lib/SNAG/Source/SystemInfo/Linux.pm
+++ b/lib/SNAG/Source/SystemInfo/Linux.pm
@@ -1319,6 +1319,7 @@ sub mounts
   {
     next if /^none/;
     next if /^\s*$/;
+    next if /^rootfs/; # ignore / mounts reporting themselves as type rootfs
 
     if(/^(\S+) on (\S+) type (\S+) \((\S+)\)( \[(\S*)\])?$/)
     {


### PR DESCRIPTION
That one liner patch to ignore '/' mounts reporting themselves as type rootfs when parsing the output of '/bin/mount -lv'
