### PR TITLE
clear out pickables when we refresh them to ensure old ones are removed properly

### DIFF
--- a/lib/SNAG/Source/Manager/NetworkDevice.pm
+++ b/lib/SNAG/Source/Manager/NetworkDevice.pm
@@ -109,6 +109,7 @@ sub new
         else
         {
           my $time = time();
+          $state->{pickables} = {};
           foreach my $row (@{$dbires->{result}})
           {
             unless (defined $row->{dns})


### PR DESCRIPTION
make sure old 'pickables' are removed from $state each time we refresh pickables. $state is persistent and not reset every run