### PR TITLE
error observed:

### DIFF
--- a/lib/SNAG/Client.pm
+++ b/lib/SNAG/Client.pm
@@ -639,7 +639,7 @@ sub create_connection
                           delete $heap->{initiated_connection};
                           delete $heap->{pending_data};
 
-                          if($heap->{server})
+                          if($heap->{server} && $heap->{connected} && !$heap->{shutdown})
                           {
                             $heap->{server}->shutdown_input();
                             $heap->{server}->shutdown_output();


### PR DESCRIPTION
  Can't locate object method "shutdown_input" via package "POE::Wheel::SocketFactory"

from the POE::Component::Client::TCP docs:
  
> The read-only server heap member contains the POE::Wheel object used to connect to or talk with the server.
>   While the component is connecting, server will be a POE::Wheel::SocketFactory object.
>   After the connection has been made, server is replaced with a POE::Wheel::ReadWrite object.
> 
>
>  The most reliable way to avoid prematurely using server is to first check the connected reserved heap member. See the example above.

check to see if connected and not shutdown. this may be overkill. another option is to check
```
  $heap->{server}->can('shutdown_input');
  $heap->{server}->can('shutdown_output');
```