### PR TITLE
table 'brmac': ERROR:  duplicate key value violates unique constraint

### DIFF
--- a/lib/SNAG/Source/xen.pm
+++ b/lib/SNAG/Source/xen.pm
@@ -384,9 +384,11 @@ sub new
 					print "$br \n";
 					@raw = `brctl showmacs $br`;
 					shift @raw;
+					my %seen = ();
 					foreach (sort @raw)
 					{
 						@brdata = split /\s+/;
+						next if $seen{$brdata[2]}++;
 						next unless $brdata[3] eq 'yes';
 						push @{$info->{brmac}}, {mac => $brdata[2]};
 						@{$info->{brmac}}[$#{$info->{brmac}}]->{local} = $brdata[3];


### PR DESCRIPTION
``brctl showmacs bridge`` can have duplicate macs. this violates the primary key.

first try was to pipe to ``uniq``, but didn't want to rely on a binary being there or always behaving the same.